### PR TITLE
Resolve issues with source installation and documentation inconsistencies.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,7 +11,7 @@ export JULIA_CPU_TARGET=generic
 export PINGPONG_LIQUIDATION_BUFFER=0.02
 
 # condapkg
-export JULIA_CONDAPKG_ENV="$(realpath $PWD/.conda)"
+export JULIA_CONDAPKG_ENV="$(realpath $PWD)/.conda"
 # export JULIA_CONDAPKG_OFFINE=yes
 # export JULIA_CONDAPKG_VERBOSITY=-1
 

--- a/README.md
+++ b/README.md
@@ -112,20 +112,21 @@ PingPong.jl requires at least Julia 1.9. Is not in the julia registry, to instal
 
 - Clone the repository:
 ```bash
-git clone --recurse-submodules https://github.com/panifie/PingPong.jl pingpong
+git clone --recurse-submodules https://github.com/panifie/PingPong.jl
 ```
-- Activate the project:
+- Check the env vars in `.envrc`, then enabled them with `direnv allow`.
 ```bash
-cd pingpong
-git submodule init
-git submodule update
-julia --project=.
+cd PingPong.jl
+direnv allow
+```
+- Activate the project specified by `JULIA_PROJECT` in the `.envrc`.
+```bash
+julia 
 ```
 - Download and build dependencies:
-```bash
-# use centralized condapkg env
-ENV["JULIA_CONDAPKG_ENV"] = joinpath(dirname(Base.active_project()), ".conda")
-import Pkg; Pkg.instantiate()
+```julia
+] instantiate
+using PingPong  # or PingPongInteractive for plotting and optimization
 ```
 
 Read the :book: documentation ([link](https://panifie.github.io/PingPong.jl/)) to learn how to get started with the bot.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,24 +51,25 @@ using PingPong # or PingPongInteractive for plotting and optimization
 
 ## Install (git)
 
-Clone the repo:
+PingPong.jl requires at least Julia 1.9. Is not in the julia registry, to install it do the following:
 
-```shell
-git clone https://github.com/panifie/PingPong.jl
-cd PingPong.jl
-``` 
-
-Check the env vars in `.envrc`, then enabled them with `direnv allow`.
-Launch julia with the `PingPong` project:
-
-``` shell
-julia --project ./PingPong
+- Clone the repository:
+```bash
+git clone --recurse-submodules https://github.com/panifie/PingPong.jl
 ```
-
-Load PingPong
-``` julia
+- Check the env vars in `.envrc`, then enabled them with `direnv allow`.
+```bash
+cd PingPong.jl
+direnv allow
+```
+- Activate the project specified by `JULIA_PROJECT` in the `.envrc`.
+```bash
+julia 
+```
+- Download and build dependencies:
+```julia
 ] instantiate
-using PingPong # or PingPongInteractive for plotting and optimization
+using PingPong  # or PingPongInteractive for plotting and optimization
 ```
 
 ## Quickstart


### PR DESCRIPTION
Resolve issues with source installation and documentation inconsistencies. There is an adjustment needed in the .envrc for first-time installers. The following export will fail because the .conda directory does not exist on the first installation.
```
export JULIA_CONDAPKG_ENV="$(realpath $PWD/.conda)"
```
With the following adjustment, you can omit `ENV["JULIA_CONDAPKG_ENV"] = joinpath(dirname(Base.active_project()), ".conda")`:
```
export JULIA_CONDAPKG_ENV="$(realpath $PWD)/.conda"
```
